### PR TITLE
v1.0.2, fix version in package.json due to yarn check failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic",
-  "version": "v1.0.1",
+  "version": "1.0.2",
   "description": "Auth0 Internal Cryptography Toolkit",
   "main": "magic.js",
   "license": "MIT",


### PR DESCRIPTION
yarn check fails to compare the installed version with the one in yarn.lock due to the `v` in the version

`error "magic" is wrong version: expected "1.0.1", got "v1.0.1"`