### PR TITLE
v1.0.3: change name in package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "8"
 install:
-  - npm install
+  - npm install --build-from-source
 script:
   - npm run test
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.0.3 - 2018-09-21
+
+### Misc
+
+- Change repo name to @auth0/magic
+
 ## v1.0.1 - 2018-09-14
 
 ### Changes

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
   stages {
     stage('Build') { 
       steps {
-        sh 'npm install'
+        sh 'npm install --build-from-source'
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "magic",
-  "version": "1.0.2",
+  "name": "@auth0/magic",
+  "version": "1.0.3",
   "description": "Auth0 Internal Cryptography Toolkit",
   "main": "magic.js",
   "license": "MIT",


### PR DESCRIPTION
- Build from source due to a bug in the node-pre-gyp
- Renaming in package.json to @auth0/magic: We want to publish magic to npm, but there's already a magic repo in npm registry.