### PR TITLE
new name: auth0-magic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
-  "name": "@auth0/magic",
+  "name": "auth0-magic",
   "version": "1.0.3",
   "description": "Auth0 Internal Cryptography Toolkit",
   "main": "magic.js",
   "license": "MIT",
-  "repository": "auth0/magic",
+  "repository": {
+	  "type": "git",
+	  "url": "https://github.com/auth0/magic.git"
+  },
   "dependencies": {
     "bcrypt": "3.0.0",
     "libsodium-wrappers-sumo": "0.7.3"


### PR DESCRIPTION
Updating name because @ indicates private/scoped repos.

Once this is merged and (if) Jenkins succeed, I'll add the 1.0.3 release in github