### PR TITLE
Add support from stream encryption/decryption with a supplied password.

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,6 +602,34 @@ For decryption, the `encryptStream.key` should be passed to `magic.DecryptStream
     })
 ```
 
+#### magic.PwdEncryptStream || magic.PwdDecryptStream
+
+Implements the same cryptographic protocols as magic.EncryptStream/magic.DecryptStream. The only difference is that PwdEncryptStream and PwdDecryptStream derive a key from a given password instead of requiring the key as an input
+
+```js
+  // key generation
+
+  const readStream = fs.createReadStream('./plaintext.txt');
+  const writeStream = fs.createWriteStream('./ciphertext.txt');
+  const encryptStream = new magic.PwdEncryptStream('a password')
+  readStream
+    .pipe(encryptStream)
+    .pipe(writeStream)
+    .on('finish', function() {
+      console.log('encrypted file written')
+    })
+```
+
+
+```js
+  const decryptStream = new magic.PwdDecryptStream('a password')
+  readStream
+    .pipe(decryptStream)
+    .pipe(writeStream)
+    .on('finish', function() {
+      console.log('decrypted file written')
+    })
+```
 
 ### alt api
 

--- a/test/magic.test.js
+++ b/test/magic.test.js
@@ -1307,6 +1307,28 @@ describe('magic tests', () => {
             })
         });
 
+        it('should return an error when stream version is incorrect', (done) => {
+          const encryptStream = new magic.EncryptStream('012345678901234567890123456789ab012345678901234567890123456789ab')
+          const decryptStream = new magic.DecryptStream('012345678901234567890123456789ab012345678901234567890123456789ab')
+          const encTextStream = fs.createWriteStream('./test/encryptedtext.txt');
+          readStream
+            .pipe(encryptStream)
+            .pipe(encTextStream)
+            .on('finish', function() {
+              fs.readFile('./test/encryptedtext.txt', (err, data) => {
+                let dataWrongStreamVersion = Buffer.concat([Buffer.from([10]), data.slice(1)])
+                decryptStream.write(dataWrongStreamVersion)
+                decryptStream.end()
+                decryptStream
+                  .on('error', function(err) {
+                    assert.ok(err)
+                    assert.equal(err.message, 'Unsupported version')
+                    done();
+                  })
+              })
+            })
+        });
+
         after(() => {
           fs.unlink('./test/decryptedtext.txt', (err) => {
             if (err) throw err

--- a/test/magic.test.js
+++ b/test/magic.test.js
@@ -1336,6 +1336,166 @@ describe('magic tests', () => {
               if (err) throw err
             })
           });
+        })
+      });
+
+      describe('stream encryption/decryption with password', () => {
+        before(() => {
+          this.HEADER_BYTES = sodium.crypto_secretstream_xchacha20poly1305_HEADERBYTES + 1;
+          this.PWD_HEADER_BYTES = sodium.crypto_pwhash_SALTBYTES + 1;
+          password = 'random passw0rd!'
+        })
+
+        after(() => {
+          fs.unlink('./test/decryptedtext.txt', (err) => {
+            if (err) throw err
+            fs.unlink('./test/encryptedtext.txt', (err) => {
+              if (err) throw err
+            })
+          })
+        })
+
+        beforeEach(() => {
+          readStream = fs.createReadStream('./test/plaintext.txt');
+          writeStream = fs.createWriteStream('./test/decryptedtext.txt');
+        });
+
+        it('should successfully encrypt and decrypt a stream with a given password', (done) => {
+          const encryptStream = new magic.PwdEncryptStream(password)
+          const decryptStream = new magic.PwdDecryptStream(password)
+          readStream
+            .pipe(encryptStream)
+            .pipe(decryptStream)
+            .pipe(writeStream)
+            .on('finish', function() {
+              fs.readFile('./test/plaintext.txt', (err, plaindata) => {
+                if (err) {
+                  throw err;
+                }
+                fs.readFile('./test/decryptedtext.txt', (err, decrdata) => {
+                  if (err) {
+                    throw err;
+                  }
+                  assert.equal(plaindata.toString(), decrdata.toString())
+                  done()
+                });
+              });
+            });
+        });
+
+        it('should throw an error if no password is passed to PwdEncryptStream', () => {
+          try {
+           const decryptStream = new magic.PwdEncryptStream()
+          } catch(err) {
+            assert.ok(err)
+            assert.equal(err.message, 'Missing password for PwdEncryptStream')
+          }
+        });
+
+        it('should throw an error if no password is passed to PwdDecryptStream', () => {
+          try {
+           const decryptStream = new magic.PwdDecryptStream()
+          } catch(err) {
+            assert.ok(err)
+            assert.equal(err.message, 'Missing password for PwdDecryptStream')
+          }
+        });
+
+        it('should encrypt the plaintext in a file and then decrypt it in a new file (asynchronous encryption/decryption)', (done) => {
+          const encryptStream = new magic.PwdEncryptStream(password)
+          const decryptStream = new magic.PwdDecryptStream(password)
+          const encTextStream = fs.createWriteStream('./test/encryptedtext.txt');
+          readStream
+            .pipe(encryptStream)
+            .pipe(encTextStream)
+            .on('finish', function() {
+              fs.createReadStream('./test/encryptedtext.txt')
+              .pipe(decryptStream)
+              .pipe(writeStream)
+              .on('close', function() {
+                fs.readFile('./test/plaintext.txt', (err, plaindata) => {
+                  if (err) {
+                    throw err;
+                  }
+                  fs.readFile('./test/decryptedtext.txt', (err, decrdata) => {
+                    if (err) {
+                      throw err;
+                    }
+                    assert.equal(plaindata.toString(), decrdata.toString())
+                    done()
+                  });
+                });
+              });
+            });
+        });
+
+        it('should return an error when decrypting a truncated encrypted file', (done) => {
+          const encryptStream = new magic.PwdEncryptStream(password)
+          const decryptStream = new magic.PwdDecryptStream(password)
+          const encTextStream = fs.createWriteStream('./test/encryptedtext.txt');
+          readStream
+            .pipe(encryptStream)
+            .pipe(encTextStream)
+            .on('finish', () => {
+              fs.readFile('./test/encryptedtext.txt', (err, data) => {
+                let lastEncrChunk = (data.length - this.HEADER_BYTES - this.PWD_HEADER_BYTES) % (magic.STREAM_CHUNK_SIZE + sodium.crypto_secretstream_xchacha20poly1305_ABYTES)
+                decryptStream.write(data.slice(0, data.length - lastEncrChunk))
+                decryptStream.end()
+                decryptStream
+                  .on('error', function(err) {
+                    assert.ok(err)
+                    assert.equal(err.message, 'Premature stream close')
+                    done();
+                  })
+              })
+            })
+        });
+
+        it('should return an error when decrypting a spliced stream', (done) => {
+          const STREAM_CHUNK_SIZE = 4096
+          const encryptStream = new magic.PwdEncryptStream(password)
+          const decryptStream = new magic.PwdDecryptStream(password)
+          const encTextStream = fs.createWriteStream('./test/encryptedtext.txt');
+          readStream
+            .pipe(encryptStream)
+            .pipe(encTextStream)
+            .on('finish', function() {
+              fs.readFile('./test/encryptedtext.txt', (err, data) => {
+                const secChunkStart = sodium.crypto_secretstream_xchacha20poly1305_HEADERBYTES + 1 + sodium.crypto_pwhash_SALTBYTES + 1;
+                const secChunkEnd = secChunkStart + magic.STREAM_CHUNK_SIZE + sodium.crypto_secretstream_xchacha20poly1305_ABYTES
+                let dataNoSecChunk = Buffer.concat([data.slice(0, secChunkStart), data.slice(secChunkEnd)])
+                decryptStream.write(dataNoSecChunk)
+                decryptStream.end()
+                decryptStream
+                  .on('error', function(err) {
+                    assert.ok(err)
+                    assert.equal(err.message, 'Corrupted chunk')
+                    done();
+                  })
+              })
+            })
+        });
+
+        it('should return an error when the password stream version is incorrect', (done) => {
+          const encryptStream = new magic.PwdEncryptStream(password)
+          const decryptStream = new magic.PwdDecryptStream(password)
+          const encTextStream = fs.createWriteStream('./test/encryptedtext.txt');
+          readStream
+            .pipe(encryptStream)
+            .pipe(encTextStream)
+            .on('finish', function() {
+              fs.readFile('./test/encryptedtext.txt', (err, data) => {
+                let dataWrongPwdStreamVersion = Buffer.concat([Buffer.from([10]), data.slice(1)])
+                decryptStream.write(dataWrongPwdStreamVersion)
+                decryptStream.end()
+                decryptStream
+                  .on('error', function(err) {
+                    assert.ok(err)
+                    assert.equal(err.message, 'Unsupported PwdEncryptionStream version')
+                    done();
+                  })
+              })
+            })
         });
       });
     });


### PR DESCRIPTION
- Move the existing stream encryption/decryption login in an Abstract class and make the existing Encrypt(Decrypt)Stream class a child of the Abstract class
- Add support from stream encryption/decryption with a supplied password. The two new apis are `magic.PwdEncryptStream` and `magic.PwdDecryptStream` with format:
_PWD_STREAM_VERSION | salt | AbstractEncryptStream_