### PR TITLE
 Add support for encryption with password

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,63 @@ magic.decrypt.aead(sk, ciphertext, nonce)
 });
 ```
 
+#### magic.pwdEncrypt.aead | magic.pwdDecrypt.aead
+Implements the same cryptographic protocols as magic.encrypt.aead/magic.decrypt.aead. The only difference is that pwdEncrypt.aead/pwdDecrypt.aead derive a key from a given password instead of requiring the key as an input.
+
+```js
+// password
+const pwd = 'randomPassword';
+
+// callback
+magic.pwdEncrypt.aead(message, pwd, (err, output) => {
+  if (err) { return cb(err); }
+  console.log(output);
+  // { alg:        'xsalsa20poly1305',
+  //   sk:         <Buffer d7 d5 dd 2c 2a eb f1 ... >,
+  //   payload:    <Buffer 41 20 73 63 72 65 61 ... >,
+  //   nonce:      <Buffer b3 4f 59 af 96 e4 4c ... >,
+  //   ciphertext: <Buffer 3c 3d 0e 8b c6 34 83 ... > }
+});
+
+// promise
+magic.pwdEncrypt.aead(message, pwd)
+  .then((output) => {
+    console.log(output);
+    // { alg:        'xsalsa20poly1305',
+    //   sk:         <Buffer d7 d5 dd 2c 2a eb f1 ... >,
+    //   payload:    <Buffer 41 20 73 63 72 65 61 ... >,
+    //   nonce:      <Buffer b3 4f 59 af 96 e4 4c ... >,
+    //   ciphertext: <Buffer 3c 3d 0e 8b c6 34 83 ... > }
+  }).catch((err) => {
+    return reject(err);
+  });
+});
+```
+
+Decryption then returns the plaintext directly, without the metadata.
+
+```js
+// password
+const pwd = 'randomPassword';
+
+// callback
+magic.pwdDecrypt.aead(pwd, ciphertext, nonce, (err, plaintext) => {
+  if (err) { return cb(err); }
+  console.log(plaintext);
+  // <Buffer 41 20 73 63 72 65 61 ... >
+});
+
+// promise
+magic.pwdDecrypt.aead(pwd, ciphertext, nonce)
+  .then((plaintext) => {
+    console.log(plaintext);
+    // <Buffer 41 20 73 63 72 65 61 ... >
+  }).catch((err) => {
+    return reject(err);
+  });
+});
+```
+
 #### magic.util.hash
 
 Implements `SHA2-384` (henceforth just `SHA384`) using OpenSSL through `crypto`. Unlike `SHA256` and `SHA512` - which are available through the alternative api - `SHA384` is resistant to length extension attacks, a capability which may be relevant in some circumstances. The `SHA2` family is standardized by [NIST](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf), and the most commonly used fast, cryptographically secure hash function.

--- a/magic.js
+++ b/magic.js
@@ -678,13 +678,15 @@ function hash(algorithm) {
 
 
 
-exports = module.exports = new Object();
-module.exports.auth      = new Object();
-module.exports.verify    = new Object();
-module.exports.encrypt   = new Object();
-module.exports.decrypt   = new Object();
-module.exports.password  = new Object();
-module.exports.util      = new Object();
+exports = module.exports  = new Object();
+module.exports.auth       = new Object();
+module.exports.verify     = new Object();
+module.exports.encrypt    = new Object();
+module.exports.decrypt    = new Object();
+module.exports.password   = new Object();
+module.exports.util       = new Object();
+module.exports.pwdEncrypt = new Object();
+module.exports.pwdDecrypt = new Object();
 
 
 /***
@@ -988,11 +990,18 @@ function sync(message, sk, cb) {
  * @param {Function} cb
  * @returns {Callback|Promise}
  */
-module.exports.decrypt.aead = (s, c, n, cb) => { return sodium.ready.then(() => { return dsync(s, c, n, cb); } ) };;
+module.exports.decrypt.aead = (s, c, n, cb) => {
+  return sodium.ready.then(() => {
+    if (!s) {
+      const done = ret(cb);
+      return done(new Error('Cannot decrypt without a key'));
+    }
+    return dsync(s, c, n, cb);
+  } )
+};
+
 function dsync(sk, ciphertext, nonce, cb) {
   const done = ret(cb);
-
-  if (!sk) { return done(new Error('Cannot decrypt without a key')); }
 
   let isk;
   [ ciphertext, nonce, sk ] = cparse(ciphertext, nonce, sk);


### PR DESCRIPTION
Two new functions `pwdEncrypt.aead` and `pwdDecrypt.aead` are introduced. They are deriving a key from the password and then use the already existing `sync()` and `dsync()` to do the actual encryption/decryption.

In pwdEncrypt() the generated salt is appended to the ciphertext. In pwdDecrypt(), the salt is
retrieved from the beginning of the ciphertext and along with the password they generate the same key. 

_Note:_ git did a mess understanding the changes in the test file. I just added 4 more tests,  two under `describe('with password required'` and two in the end of the "failure" section