### PR TITLE
Add timing safe string comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,35 @@ magic.util.hash(message)
 });
 ```
 
+#### magic.util.timingSafeCompare
+
+Implements a timing safe comparision between two strings.  The comparison is completed through hashing both strings using the core `magic.util.hash` function in parallel. The two hash buffers are then compared using the timing safe buffer comparision using `crypto` module (falling back to `libsodium` if `crypto` is not available). 
+
+*Recommended use: Best used when comparing sensitive information that is transmitted in clear text but is not practical to store, and encrypt or hash. An example would be to check whether an input string matches an environment variable. When in doubt, use encryption and hashing functions.*
+
+```js
+//promise
+magic.util.timingSafeCompare(inputString, referenceString).then((result) => {
+  // result: 'true' or 'false'
+  // do stuff based on true/false
+  }).catch((err) => {
+    // handle error
+  });
+
+// async/await
+try {
+  let stringsAreTheSame = await timingSafeCompare(inputString, referenceString);
+  if (stringsAreTheSame) {
+    // do stuff based on true/false
+  }
+} catch (err) {
+  // handle error
+}
+
+
+```
+
+
 #### magic.password.hash | magic.verify.password
 
 Implements `argon2id` password hashing using `libsodium.js`. The winner of the [Password Hashing Competition](https://password-hashing.net/) and now the [OWASP recommendation](https://www.owasp.org/index.php/Password_Storage_Cheat_Sheet#Leverage_an_adaptive_one-way_function), `argon2id` is robust against both memory tradeoff and side-channel attacks. The output of the `argon2id` function is encoded with a prefix and other metadata, and so `output.hash` is encoded as a string, not a raw binary buffer as is normal for the rest of the `magic` api. Nor is the raw password itself returned.

--- a/magic.js
+++ b/magic.js
@@ -1221,6 +1221,23 @@ function uid(sec, cb) {
   }).catch((err) => { return done(err); })
 }
 
+/**
+ * Provides timing safe comparisons of two strings to prevent
+ * timing based attacks. Returns a Promise of a true Boolean
+ * value if strings are the same.
+ * @function
+ * @api public
+ * 
+ * @param {string} inputString - The first string to check
+ * @param {string} referenceString - The reference string to check against
+ * @returns {Promise} Returns a promise of a Boolean value
+ */
+module.exports.util.timingSafeCompare = async function (inputString, referenceString) {
+  let referencePromise = module.exports.util.hash(referenceString);
+  let inputPromise = module.exports.util.hash(inputString);
+  const hashes = await Promise.all([referencePromise, inputPromise]);
+  return cnstcomp(hashes[0].hash, hashes[1].hash);
+};
 
 /*****************
  *    Streams    *

--- a/test/magic.test.js
+++ b/test/magic.test.js
@@ -1168,6 +1168,42 @@ describe('magic tests', () => {
         });
       });
 
+      describe('timingSafeCompare', () => {
+        it('should return true when strings are the same', (done) => {
+          const str1 = 'This is the same input';
+          const str2 = str1;
+
+          magic.util.timingSafeCompare(str1, str2).then(function (result) {
+            assert(result);
+            done();
+          });
+        });
+
+        it('should return false when strings are not the same', (done) => {
+          const str1 = 'This is the same input';
+          const str2 = 'other string';
+
+          magic.util.timingSafeCompare(str1, str2).then(function (result) {
+            assert(!result);
+            done();
+          });
+        });
+
+        it('should work for a large number of unicode characters', (done) => {
+          var str1;
+          // 500 was chosen to cover many unicode characters, even though a much
+          // smaller subset is likely to be used.
+          for (i=0; i < 500; i++) {
+            str1 += String.fromCharCode(i);
+          }
+          const str2 = str1;
+
+          magic.util.timingSafeCompare(str1, str2).then(function (result) {
+            assert(result);
+            done();
+          });
+        });
+      });
 
       describe('rand', () => {
 


### PR DESCRIPTION
There are situations where we may need to compare two strings that
contain sensitive information and it isn't practical to store those
strings. When comparing two strings, many of the comparison methods,
such as `===` compare character by character. In this case, an attacker
could exfiltrate sensitive information through a timing attack.

The purpose of this utility function is to provide a simple API that
engineers can use to compare two strings and be protected from a
timing based attack. Other timing safe comparison methods usually
require equal sized buffers which can be challenging to use and also
maintain timing safe qualities.

Added tests for the utility function and updated documentation.