### PR TITLE
Add timing safe string comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,16 @@ magic.util.hash(message)
 });
 ```
 
+#### magic.util.timingSafeCompare
+
+Implements a timing safe comparision between two strings. The comparision is completed using the timing safe buffer comparision using `crypto` module (falling back to `libsodium` if `crypto` is not available) and string length checks. 
+
+*Recommended use: Best used when comparing sensitive information that is transmitted in clear text but is not practical to store, and encrypt or hash. An example would be to check whether an input string matches an environment variable. When in doubt, use encryption and hashing functions.*
+
+```js
+var stringsAreTheSame = magic.util.timingSafeCompare(inputString, referenceString);
+```
+
 #### magic.password.hash | magic.verify.password
 
 Implements `argon2id` password hashing using `libsodium.js`. The winner of the [Password Hashing Competition](https://password-hashing.net/) and now the [OWASP recommendation](https://www.owasp.org/index.php/Password_Storage_Cheat_Sheet#Leverage_an_adaptive_one-way_function), `argon2id` is robust against both memory tradeoff and side-channel attacks. The output of the `argon2id` function is encoded with a prefix and other metadata, and so `output.hash` is encoded as a string, not a raw binary buffer as is normal for the rest of the `magic` api. Nor is the raw password itself returned.

--- a/magic.js
+++ b/magic.js
@@ -1240,19 +1240,22 @@ module.exports.util.timingSafeCompare = (input, ref) => {
   let inputLength = Buffer.byteLength(input);
   let refLength = Buffer.byteLength(ref);
 
-  /*  Allocate two buffers, making the input buffer the length. 
+  /* 
+  Allocate two buffers, making the input buffer the length. 
   Continue the comparison of the two buffers 
   with the length evaluation failing at the end to not give
   away the length of the reference string.  
   */
   let inputBuffer = Buffer.alloc(inputLength);
-  inputBuffer.write(input, 0, inputLength);
+  inputBuffer.write(input);
   let refBuffer = Buffer.alloc(inputLength);
 
-  // write the reference string, to the size of the inputString
-  // this could lead to false positives, but we'll catch that with a length
-  // check at the end. 
-  refBuffer.write(ref, 0, inputLength);
+  /* 
+  Write the reference string, to the size of the inputString.
+  This could lead to false positives, when substrings are 
+  involved but we'll catch those with a length check at the end. 
+  */  
+  refBuffer.write(ref);
   // check buffers and their lengths
   return cnstcomp(inputBuffer, refBuffer) && inputLength === refLength;
 };

--- a/magic.js
+++ b/magic.js
@@ -1221,6 +1221,41 @@ function uid(sec, cb) {
   }).catch((err) => { return done(err); })
 }
 
+/**
+ * Provides timing safe comparisons of two strings to prevent
+ * timing based attacks. Returns true if the strings are the
+ * same and false if not.
+ * @function
+ * @api public
+ * 
+ * @param {string} input - The first string to check
+ * @param {string} ref - The reference string to check against
+ * @returns {Boolean} - true if they match, false otherwise
+ */
+module.exports.util.timingSafeCompare = (input, ref) => {
+  inputIsString = typeof input === 'string' || input instanceof String;
+  refIsString = typeof ref === 'string' || ref instanceof String;
+  if (!inputIsString || !refIsString) throw new TypeError('Inputs must be Strings');
+  
+  let inputLength = Buffer.byteLength(input);
+  let refLength = Buffer.byteLength(ref);
+
+  /*  Allocate two buffers, making the input buffer the length. 
+  Continue the comparison of the two buffers 
+  with the length evaluation failing at the end to not give
+  away the length of the reference string.  
+  */
+  let inputBuffer = Buffer.alloc(inputLength);
+  inputBuffer.write(input, 0, inputLength);
+  let refBuffer = Buffer.alloc(inputLength);
+
+  // write the reference string, to the size of the inputString
+  // this could lead to false positives, but we'll catch that with a length
+  // check at the end. 
+  refBuffer.write(ref, 0, inputLength);
+  // check buffers and their lengths
+  return cnstcomp(inputBuffer, refBuffer) && inputLength === refLength;
+};
 
 /*****************
  *    Streams    *

--- a/test/magic.test.js
+++ b/test/magic.test.js
@@ -1256,10 +1256,10 @@ describe('magic tests', () => {
           var values = performanceMatrix.concat();
           values.sort();
           var lowerq = values[Math.floor((values.length / 4))];
-          var upperq = values[Math.ceil((values.length * (3/4)))];
+          var upperq = values[Math.ceil((values.length * (3 / 4)))];
           var iqr = upperq - lowerq;
-          var maxValue = upperq + iqr*1.5;
-          var minValue = lowerq - iqr*1.5;
+          var maxValue = upperq + iqr * 1.5;
+          var minValue = lowerq - iqr * 1.5;
 
           var outliers = values.filter((x) => {
             return (x >= maxValue) || (x <= minValue);

--- a/test/magic.test.js
+++ b/test/magic.test.js
@@ -4,7 +4,7 @@ const crypto = require('crypto');
 const sodium = require('libsodium-wrappers-sumo');
 const assert = require('assert');
 const fs = require('fs');
-
+const { performance } = require('perf_hooks');
 
 describe('magic tests', () => {
 
@@ -1168,6 +1168,108 @@ describe('magic tests', () => {
         });
       });
 
+      describe('timingSafeCompare', () => {
+        it('should return true when strings are the same', (done) => {
+          const str1 = 'This is the same input';
+          const str2 = str1;
+          assert(magic.util.timingSafeCompare(str1, str2));
+          done();
+        });
+
+        it('should return true when strings are the same literals', (done) => {
+          const str1 = 'This is the same input';
+          const str2 = 'This is the same input';
+          assert(magic.util.timingSafeCompare(str1, str2));
+          done();
+        });
+
+        it('should return false when strings are not the same', (done) => {
+          const str1 = 'This is the same input';
+          const str2 = 'other string';
+          assert(!magic.util.timingSafeCompare(str1, str2));
+          done();
+        });
+
+        it('should return false when ref string is a substring of the input', (done) => {
+          const str1 = 'This is the same input';
+          const str2 = 'This is the same';
+          assert(!magic.util.timingSafeCompare(str1, str2));
+          done();
+        });
+
+        it('should return false when input string is a substring of the ref', (done) => {
+          const str1 = 'This is the ';
+          const str2 = 'This is the same';
+          assert(!magic.util.timingSafeCompare(str1, str2));
+          done();
+        });
+
+        it('should return false when strings are not the same but are of the same length', (done) => {
+          const str1 = 'This is the same input';
+          const str2 = 'This isnt the same tho';
+          assert(!magic.util.timingSafeCompare(str1, str2));
+          done();
+        });
+
+        it('should work for a large number of unicode characters', (done) => {
+          var str1;
+          // Iterate over all UTF-16 characters
+          for (i=0; i < 65535; i++) {
+            str1 += String.fromCharCode(i);
+          }
+          const str2 = str1;
+          assert(magic.util.timingSafeCompare(str1, str2));
+          done();
+        });
+
+        it('should work with a null terminated character', (done) => {
+          const str1 = 'This is the same\0\0\0';
+          const str2 = 'This is the same yo';
+          assert(str1.length === str2.length);
+          assert(!magic.util.timingSafeCompare(str1, str2));
+          done();
+        });
+
+        it('should not make the length easily discoverable', (done) => {
+          var performanceMatrix = [];
+          var str1 = 'abcdefghijklmnopqrstuvwxyz';
+          var str2 = '';
+
+          // Check the timing of each string and 
+          // compare with the reference timing to see
+          // if it is easily discernable
+          for (i=0; i < 1000; i++) {
+            var t0 = performance.now();
+            magic.util.timingSafeCompare(str2, str1);
+            var t1 = performance.now();
+            performanceMatrix[i] = t1-t0;
+            // Any character is fine
+            str2 += String.fromCharCode(i);
+          }
+          var reference = performanceMatrix[str1.length];
+
+          // We will assume items that are outside of the whiskers
+          // of a normal distribution is considered discernable
+          // (0.7% of the values in a normal distribution)
+          // https://en.wikipedia.org/wiki/Interquartile_range
+           
+          var values = performanceMatrix.concat();
+          values.sort();
+          var lowerq = values[Math.floor((values.length / 4))];
+          var upperq = values[Math.ceil((values.length * (3/4)))];
+          var iqr = upperq - lowerq;
+          var maxValue = upperq + iqr*1.5;
+          var minValue = lowerq - iqr*1.5;
+
+          var outliers = values.filter((x) => {
+            return (x >= maxValue) || (x <= minValue);
+          });
+
+          assert(!outliers.includes(reference));
+          done();
+        });
+
+      });
 
       describe('rand', () => {
 


### PR DESCRIPTION
There are situations where we may need to compare two strings that
contain sensitive information and it isn't practical to store those
strings. When comparing two strings, many of the comparison methods,
such as `===` compare character by character. In this case, an attacker
could exfiltrate sensitive information through a timing attack.

The purpose of this utility function is to provide a simple API that
engineers can use to compare two strings and be protected from a
timing based attack. Other timing safe comparison methods usually
require equal sized buffers which can be challenging to use and also
maintain timing safe qualities.

Added tests for the utility function and updated documentation.