### PR TITLE
PS-543: Export a function for RSA keypair generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "8"
+  - "10"
 install:
   - npm install --build-from-source
 script:

--- a/README.md
+++ b/README.md
@@ -494,9 +494,38 @@ magic.util.hash(message)
 });
 ```
 
+#### magic.util.rsaKeypairGen
+
+Generates an RSA public/private key pair. The public key is encoded using a SubjectPublicKeyInfo(SPKI) structure. For node 10+, it uses the built-in `generateKeyPair` from `crypto` library. For older node versions, it generates the keypair using OpenSSL directly.
+
+```js
+// callback
+magic.util.rsaKeypairGen((err, keypair) => {
+  if (err) { return cb(err); }
+  console.log(keypair)
+  // {
+  //   sk: '-----BEGIN RSA PRIVATE KEY-----\nMIIEogIBi...6gA=\n-----END RSA PRIVATE KEY-----\n',
+  //   pk: '-----BEGIN RSA PUBLIC KEY-----\nMIIBCgKCAQE...ApIDAQAB\n-----END RSA PUBLIC KEY-----\n'
+  //  }
+});
+
+// promise
+magic.util.rsaKeypairGen()
+.then((keypair) => {
+  console.log(keypair)
+  // {
+  //   sk: '-----BEGIN RSA PRIVATE KEY-----\nMIIEogIBi...6gA=\n-----END RSA PRIVATE KEY-----\n',
+  //   pk: '-----BEGIN RSA PUBLIC KEY-----\nMIIBCgKCAQE...ApIDAQAB\n-----END RSA PUBLIC KEY-----\n'
+  //  }
+})
+.catch((err) => {
+  return reject(err);
+});
+```
+
 #### magic.util.timingSafeCompare
 
-Implements a timing safe comparision between two strings. The comparision is completed using the timing safe buffer comparision using `crypto` module (falling back to `libsodium` if `crypto` is not available) and string length checks. 
+Implements a timing safe comparision between two strings. The comparision is completed using the timing safe buffer comparision using `crypto` module (falling back to `libsodium` if `crypto` is not available) and string length checks.
 
 *Recommended use: Best used when comparing sensitive information that is transmitted in clear text but is not practical to store, and encrypt or hash. An example would be to check whether an input string matches an environment variable. When in doubt, use encryption and hashing functions.*
 

--- a/magic.js
+++ b/magic.js
@@ -1260,6 +1260,53 @@ module.exports.util.timingSafeCompare = (input, ref) => {
   return cnstcomp(inputBuffer, refBuffer) && inputLength === refLength;
 };
 
+
+/*
+ * rsaKeypairGen
+ *
+ * Get an RSA private/public keypair
+ *
+ * @function
+ * @api public
+ *
+ * @param {Function} cb
+ * @returns {Callback|Promise}
+ */
+
+module.exports.util.rsaKeypairGen = (cb) => {
+  const done  = ret(cb)
+
+  if (crypto.generateKeyPair) { // node >= 10
+    return new Promise((resolve, reject) => {
+      crypto.generateKeyPair('rsa', {
+        modulusLength: 2048,
+        publicExponent: 65537,
+        publicKeyEncoding: {
+          type: 'spki',
+          format: 'pem'
+        },
+        privateKeyEncoding: {
+          type: 'pkcs1',
+          format: 'pem'
+        }
+      }, (err, publicKey, privateKey) => {
+        return resolve(done(null, {sk: privateKey, pk: publicKey}));
+      });
+    })
+  } else {
+    return new Promise((resolve, reject) => {
+      extcrypto.keygen((err, sk, pk) => {
+        if (err) { return reject(done(new Error(err.message))); }
+
+        extcrypto.extractSPKI(sk, (err, pk) => {
+          if (err) { return reject(done(new Error(err.message))); }
+          return resolve(done(null, {sk: sk, pk: pk}));
+        });
+      });
+    })
+  }
+};
+
 /*****************
  *    Streams    *
  *****************/

--- a/test/magic.test.js
+++ b/test/magic.test.js
@@ -1235,7 +1235,7 @@ describe('magic tests', () => {
           var str1 = 'abcdefghijklmnopqrstuvwxyz';
           var str2 = '';
 
-          // Check the timing of each string and 
+          // Check the timing of each string and
           // compare with the reference timing to see
           // if it is easily discernable
           for (i=0; i < 1000; i++) {
@@ -1252,7 +1252,7 @@ describe('magic tests', () => {
           // of a normal distribution is considered discernable
           // (0.7% of the values in a normal distribution)
           // https://en.wikipedia.org/wiki/Interquartile_range
-           
+
           var values = performanceMatrix.concat();
           values.sort();
           var lowerq = values[Math.floor((values.length / 4))];
@@ -1269,6 +1269,35 @@ describe('magic tests', () => {
           done();
         });
 
+      });
+
+      describe('rsaKeypairGen', () => {
+
+        it('should return an object containing a public and a private key - callback api', (done) => {
+          magic.util.rsaKeypairGen((err, keypair) => {
+            assert.ok(!err);
+            assert.ok(keypair);
+            assert.ok(keypair.sk)
+            assert.ok(keypair.pk)
+
+            assert.ok(keypair.sk.startsWith('-----BEGIN RSA PRIVATE KEY-----'))
+            assert.ok(keypair.pk.startsWith('-----BEGIN PUBLIC KEY-----'))
+
+            done();
+          });
+        });
+
+        it('should return an object containing a public and a private key - promise api', (done) => {
+          magic.util.rsaKeypairGen().then((keypair) => {
+            assert.ok(keypair);
+            assert.ok(keypair.sk)
+            assert.ok(keypair.pk)
+            assert.ok(keypair.sk.startsWith('-----BEGIN RSA PRIVATE KEY-----'))
+            assert.ok(keypair.pk.startsWith('-----BEGIN PUBLIC KEY-----'))
+
+            done();
+          }).catch((err) => { assert.ok(!err); });
+        });
       });
 
       describe('rand', () => {


### PR DESCRIPTION
### Description
Generates an RSA private/public keypair. The public key is encoded using a SubjectPublicKeyInfo(SPKI) structure. For node 10+, it uses the built-in `generateKeyPair` from `crypto` library. For older node versions, it generates the keypair using OpenSSL directly by utilizing existing private functions in excrypto.cc

### Testing
`npm test` passes successfully

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
