### PR TITLE
Rename the output of rsaKeypairGen

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,8 +504,8 @@ magic.util.rsaKeypairGen((err, keypair) => {
   if (err) { return cb(err); }
   console.log(keypair)
   // {
-  //   sk: '-----BEGIN RSA PRIVATE KEY-----\nMIIEogIBi...6gA=\n-----END RSA PRIVATE KEY-----\n',
-  //   pk: '-----BEGIN RSA PUBLIC KEY-----\nMIIBCgKCAQE...ApIDAQAB\n-----END RSA PUBLIC KEY-----\n'
+  //   privateKey: '-----BEGIN RSA PRIVATE KEY-----\nMIIEogIBi...6gA=\n-----END RSA PRIVATE KEY-----\n',
+  //   publicKey: '-----BEGIN RSA PUBLIC KEY-----\nMIIBCgKCAQE...ApIDAQAB\n-----END RSA PUBLIC KEY-----\n'
   //  }
 });
 
@@ -514,8 +514,8 @@ magic.util.rsaKeypairGen()
 .then((keypair) => {
   console.log(keypair)
   // {
-  //   sk: '-----BEGIN RSA PRIVATE KEY-----\nMIIEogIBi...6gA=\n-----END RSA PRIVATE KEY-----\n',
-  //   pk: '-----BEGIN RSA PUBLIC KEY-----\nMIIBCgKCAQE...ApIDAQAB\n-----END RSA PUBLIC KEY-----\n'
+  //   privateKey: '-----BEGIN RSA PRIVATE KEY-----\nMIIEogIBi...6gA=\n-----END RSA PRIVATE KEY-----\n',
+  //   publicKey: '-----BEGIN RSA PUBLIC KEY-----\nMIIBCgKCAQE...ApIDAQAB\n-----END RSA PUBLIC KEY-----\n'
   //  }
 })
 .catch((err) => {

--- a/magic.js
+++ b/magic.js
@@ -1290,17 +1290,17 @@ module.exports.util.rsaKeypairGen = (cb) => {
           format: 'pem'
         }
       }, (err, publicKey, privateKey) => {
-        return resolve(done(null, {sk: privateKey, pk: publicKey}));
+        return resolve(done(null, {privateKey, publicKey}));
       });
     })
   } else {
     return new Promise((resolve, reject) => {
-      extcrypto.keygen((err, sk, pk) => {
+      extcrypto.keygen((err, privateKey) => {
         if (err) { return reject(done(new Error(err.message))); }
 
-        extcrypto.extractSPKI(sk, (err, pk) => {
+        extcrypto.extractSPKI(privateKey, (err, publicKey) => {
           if (err) { return reject(done(new Error(err.message))); }
-          return resolve(done(null, {sk: sk, pk: pk}));
+          return resolve(done(null, {privateKey, publicKey}));
         });
       });
     })

--- a/test/magic.test.js
+++ b/test/magic.test.js
@@ -1277,11 +1277,11 @@ describe('magic tests', () => {
           magic.util.rsaKeypairGen((err, keypair) => {
             assert.ok(!err);
             assert.ok(keypair);
-            assert.ok(keypair.sk)
-            assert.ok(keypair.pk)
+            assert.ok(keypair.privateKey)
+            assert.ok(keypair.publicKey)
 
-            assert.ok(keypair.sk.startsWith('-----BEGIN RSA PRIVATE KEY-----'))
-            assert.ok(keypair.pk.startsWith('-----BEGIN PUBLIC KEY-----'))
+            assert.ok(keypair.privateKey.startsWith('-----BEGIN RSA PRIVATE KEY-----'))
+            assert.ok(keypair.publicKey.startsWith('-----BEGIN PUBLIC KEY-----'))
 
             done();
           });
@@ -1290,10 +1290,11 @@ describe('magic tests', () => {
         it('should return an object containing a public and a private key - promise api', (done) => {
           magic.util.rsaKeypairGen().then((keypair) => {
             assert.ok(keypair);
-            assert.ok(keypair.sk)
-            assert.ok(keypair.pk)
-            assert.ok(keypair.sk.startsWith('-----BEGIN RSA PRIVATE KEY-----'))
-            assert.ok(keypair.pk.startsWith('-----BEGIN PUBLIC KEY-----'))
+            assert.ok(keypair.privateKey)
+            assert.ok(keypair.publicKey)
+
+            assert.ok(keypair.privateKey.startsWith('-----BEGIN RSA PRIVATE KEY-----'))
+            assert.ok(keypair.publicKey.startsWith('-----BEGIN PUBLIC KEY-----'))
 
             done();
           }).catch((err) => { assert.ok(!err); });


### PR DESCRIPTION


### Description

Renaming the output of  `magic.until.rsaKeypairGen` from
```
{
sk: '-----BEGIN RSA PRIVATE KEY-----.....',
pk: '-----BEGIN RSA PUBLIC KEY-----......'
}
```
to
```
{
privateKey: '-----BEGIN RSA PRIVATE KEY-----.....',
publicKey: '-----BEGIN RSA PUBLIC KEY-----......'
}
```
to better align with the output from  the built-in `generateKeyPair` from `crypto` library.

Since this is a breaking change, a version 3.0.0 will be released once this PR is merged.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
