### PR TITLE
Release version 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## v3.0.0 - 2019-07-09
+
+### Changes
+- Renames the output of magic.util.rsaKeypairGen() from
+{ sk: ... , pk ...} to { privateKey: ... , publicKey: ...}
+
 ## v2.5.0 - 2019-07-03
 
 ### Adds

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-magic",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-magic",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "description": "Auth0 Internal Cryptography Toolkit",
   "main": "magic.js",
   "license": "MIT",


### PR DESCRIPTION
### Description

Release version 3.0.0
Breaking change: Renames the output of `magic.util.rsaKeypairGen()` from
`{ sk: ... , pk ...}` to `{ privateKey: ... , publicKey: ...}`