### PR TITLE
Drop support for node 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,16 +15,10 @@ commands:
 workflows:
   main:
     jobs:
-      - unit-tests-node8
       - unit-tests-node10
       - unit-tests-node12
 
 jobs:
-  unit-tests-node8:
-    docker:
-      - image: circleci/node:8
-    steps:
-      - runtests
   unit-tests-node10:
     docker:
       - image: circleci/node:10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-## v4.0.0 - 2020-08-31
+## v4.0.0 - 2020-09-02
 
 ### Changes
+- Drops support for node 8 due to bcrypt update
 - Updates bcrypt to version 5.x. This is a breaking change only in case of a
   passphrase longer than 255 or a passphrase that includes null byte
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
   }
 
   tools {
-    nodejs '8.9.1'
+    nodejs '10.21.0'
   }
 
   environment {

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   },
   "devDependencies": {
     "mocha": "^5.1.1"
+  },
+  "engines" : {
+    "node" : ">=10"
   }
 }


### PR DESCRIPTION
### Description

Drops support for node 8, due to the bcrypt version update: 


### References

1. bcrypt <> node versions' compatibility: https://www.npmjs.com/package/bcrypt#version-compatibility
2. bcrypt update: https://github.com/auth0/magic/pull/69
