### PR TITLE
docs: fix issue in stream encryption description

### DIFF
--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -322,7 +322,7 @@ magic.pwdDecrypt.aead(pwd, ciphertext, nonce)
 
 Implements `xchacha20poly1305` authenticated encryption using `libsodium.js` for streams.
 
-The ChaCha20-Poly1305 symmetric authenticated encryption scheme been standardized by the [IETF](https://tools.ietf.org/html/rfc7539). The scheme is fast, simple, and as an AEAD construction provides confidentiality, authentication, and integrity on the message.
+[XChaCha20-Poly1305](https://libsodium.gitbook.io/doc/secret-key_cryptography/aead/chacha20-poly1305/xchacha20-poly1305_construction) is a symmetric authenticated encryption scheme, an improvement to the IETF-standardized [ChaCha20-Poly1305](https://tools.ietf.org/html/rfc7539). XChaCha's improvement over ChaCha is due to the usage of extended 192 bit nonces. The scheme is fast, simple, and as an AEAD construction provides confidentiality, authentication and integrity on the message.
 
 For stream encryption/decryption using a password instead of a key, see
 [magic.PwdEncryptStream | magic.PwdDecryptStream](#magicpwdencryptstream--magicpwddecryptstream)


### PR DESCRIPTION
### Description

XChaCha20-Poly1305 is the one used for stream encryption: https://github.com/auth0/magic/blob/a1a16d51c1ec73b5a45a5b75916d6220d9cfa78d/magic.js#L1351 however the documentation mentions ChaCha20-Poly1305 which is a different algorithm. This PR fixes the documentation to mention the correct algorithm.